### PR TITLE
Handle null streamingRespMethods in fetch transport

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -52,14 +52,13 @@ export class TwirpError extends Error {
 		const { msg, message } = twerrObj
 		if (!msg && !message) {
 			super(`Badly formed twirp error: must have msg or message field, got "${JSON.stringify(twerrObj)}"`)
-			return
-		}
-		if (msg && message) {
+		} else if (msg && message) {
 			super(`Badly formed twirp error: cannot have both msg and message fields, got msg="${msg}" and message="${message}"`)
-			return
+		} else {
+			super(msg || message)
 		}
-		super(msg || message)
 		this.name = this.constructor.name
+		this.meta = {} // ensure meta property exists, incase twerrObj is a generic error.
 		for (const kk of Object.keys(twerrObj)) {
 			this[kk] = twerrObj[kk]
 		}

--- a/transports/fetch_transport.js
+++ b/transports/fetch_transport.js
@@ -43,7 +43,9 @@ export default function createFetchTransport(twirpURL, options = {}) {
 		const req = requestCtor.encode(request).finish()
 		const resp = await sendReqAndCheckResp(twirpURL, method, req, fetchOptions)
 
-		if (!streamingRespMethods.includes(method.name)) { // unary response
+		// Check for a streaming endpoint
+		if (!streamingRespMethods || !streamingRespMethods.includes(method.name)) {
+			// This is a unary response
 			const buf = await resp.arrayBuffer()
 			const respContent = responseCtor.decode(new Uint8Array(buf))
 			return respContent


### PR DESCRIPTION
When using the default fetch transport on a non-streaming service, I was getting the error `streamingRespMethods is null`. This pull request fixes that issue.